### PR TITLE
added option to read userinfo from the tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2025-06-20
+
+- Option to retrieve user claims from the tokens instead of the user info endpoint.
+
 ## [5.1.1] - 2025-01-18
 
 ### Added

--- a/Controller.php
+++ b/Controller.php
@@ -224,18 +224,25 @@ class Controller extends \Piwik\Plugin\Controller
         $_SESSION['loginoidc_idtoken'] = empty($result->id_token) ? null : $result->id_token;
         $_SESSION['loginoidc_auth'] = true;
 
-        $curl = curl_init();
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array(
-            "Authorization: Bearer " . $result->access_token,
-            "Accept: application/json",
-            "User-Agent: RebelOIDC-Matomo-Plugin"
-        ));
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_URL, $settings->userInfoUrl->getValue());
-        // request remote userinfo and remote user id
-        $response = curl_exec($curl);
-        curl_close($curl);
-        $result = json_decode($response);
+        if (!$settings->userInfoFromToken->getValue()) {
+            // request userinfo from remote server
+            $curl = curl_init();
+            curl_setopt($curl, CURLOPT_HTTPHEADER, array(
+                "Authorization: Bearer " . $result->access_token,
+                "Accept: application/json",
+                "User-Agent: RebelOIDC-Matomo-Plugin"
+            ));
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curl, CURLOPT_URL, $settings->userInfoUrl->getValue());
+            // request remote userinfo and remote user id
+            $response = curl_exec($curl);
+            curl_close($curl);            
+            $result = json_decode($response);
+        } else{
+            // use the current token (fields) as source for userinfo
+            $result = new \stdClass();
+            foreach ($decodedToken as $key => $value) $result->{$key} = $value;
+        }
 
         $userInfoId = $settings->userInfoId->getValue();
         $providerUserId = $result->$userInfoId;

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -103,6 +103,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
      */
     public $userInfoId;
 
+    /**
+     * take the user information from the token response instead of the user info endpoint.
+     *
+     * @var Setting
+     */
+    public $userInfoFromToken;
+
      /**
      * Use the e-mail address as username.
      *
@@ -191,6 +198,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->authorizeUrl = $this->createAuthorizeUrlSetting();
         $this->tokenUrl = $this->createTokenUrlSetting();
         $this->userInfoUrl = $this->createUserInfoUrlSetting();
+        $this->userInfoFromToken = $this->createUserInfoFromTokenSetting();
         $this->endSessionUrl = $this->createEndSessionUrlSetting();
         $this->userInfoId = $this->createUserInfoIdSetting();
         $this->usernameAttribute = $this->createUsernameAttributeSetting();
@@ -344,6 +352,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->description = Piwik::translate("RebelOIDC_SettingUserInfoUrlHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_URL;
             $field->validators[] = new UrlLike();
+        });
+    }
+
+    /**
+     * Add userInfo url setting.
+     *
+     * @return SystemSetting
+     */
+    private function createUserInfoFromTokenSetting(): SystemSetting
+    {
+        return $this->makeSetting("userInfoFromToken", $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+            $field->title = Piwik::translate("RebelOIDC_SettingUserInfoFromToken");
+            $field->description = Piwik::translate("RebelOIDC_SettingUserInfoFromTokenHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
         });
     }
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -16,6 +16,8 @@
     "SettingTokenUrlHelp": "z.B. https://<USERNAME>.eu.auth0.com/oauth/token",
     "SettingUserInfoUrl": "Userinfo URL",
     "SettingUserInfoUrlHelp": "z.B. https://<USERNAME>.eu.auth0.com/userinfo",
+    "SettingUserInfoFromToken": "Userinfo aus token",
+    "SettingUserInfoFromTokenHelp": "Nehme die Benutzerinformationen aus dem Token anstelle des Userinfo-Endpunkts. Dies ist nützlich für Anbieter, die keine Ansprüche am Userinfo-Endpunkt unterstützen.",
     "SettingEndSessionUrl": "Logout URL",
     "SettingEndSessionUrlHelp": "Nach dem Logout wird der Benutzer zu dieser URL weitergeleitet, damit die Session beim Provider beendet wird. Bei Unklarheit sollte dieses Feld freigelassen werden.",
     "SettingUserInfoId": "Userinfo ID",

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,6 +18,8 @@
     "SettingTokenUrlHelp": "e.g. https://<USERNAME>.eu.auth0.com/oauth/token",
     "SettingUserInfoUrl": "Userinfo URL",
     "SettingUserInfoUrlHelp": "e.g. https://<USERNAME>.eu.auth0.com/userinfo",
+    "SettingUserInfoFromToken": "Userinfo from token",
+    "SettingUserInfoFromTokenHelp": "Take the user information from the token instead of the userinfo endpoint. This is useful for providers that do not support claims on the userinfo endpoint.",
     "SettingEndSessionUrl": "Logout URL",
     "SettingEndSessionUrlHelp": "After logging out, the user is redirected to this URL to end the session at the provider. If you are unsure, just leave this field empty.",
     "SettingUserInfoId": "Userinfo ID",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -16,6 +16,8 @@
     "SettingTokenUrlHelp": "ex. https://<USERNAME>.eu.auth0.com/oauth/token",
     "SettingUserInfoUrl": "URL Userinfo",
     "SettingUserInfoUrlHelp": "ex. https://<USERNAME>.eu.auth0.com/userinfo",
+    "SettingUserInfoFromToken": "Userinfo depuis le token",
+    "SettingUserInfoFromTokenHelp": "Récupérez les informations utilisateur à partir du jeton plutôt que du point de terminaison userinfo. Ceci est utile pour les fournisseurs qui ne prennent pas en charge les revendications sur le point de terminaison userinfo.",
     "SettingEndSessionUrl": "URL Logout",
     "SettingEndSessionUrlHelp": "",
     "SettingUserInfoId": "ID Userinfo",


### PR DESCRIPTION
This PR addresses #22 and adds an option to read userinfo claims from the token instead of going to the userinfo endpoint at all. This is required to support IDPs that don't return claims on userinfo (like ADFS does).