### PR TITLE
FEATURE: Fine-Grained permissions for users based on claim

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -40,6 +40,11 @@ class Controller extends \Piwik\Plugin\Controller
     public const OIDC_PROVIDER = 'oidc';
 
     /**
+     * @var string[]
+     */
+    public const ALLOWED_PERMISSIONS = ['admin', 'write', 'view'];
+
+    /**
      * Auth implementation to login users.
      * @var Auth
      */
@@ -245,6 +250,7 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         $user = $this->getUserByRemoteId(self::OIDC_PROVIDER, $providerUserId);
+        $userOIDCPermissions = $this->extractPermissions($decodedToken);
 
 
         // auto linking
@@ -257,16 +263,19 @@ class Controller extends \Piwik\Plugin\Controller
                     $this->linkAccount($providerUserId, $providerUserId);
                 }
                 $user = $this->getUserByRemoteId(self::OIDC_PROVIDER, $providerUserId);
+                $this->assignPermissions($userOIDCPermissions, $user['login']);
             }
         }
 
         if (empty($user)) {
             if (Piwik::isUserIsAnonymous()) {
                 // user with the remote id is currently not in our database
-                $this->signupUser($settings, $providerUserId, $result->email, $result);
+                $this->signupUser($settings, $providerUserId, $result->email, $result, $userOIDCPermissions);
             } else {
                 // link current user with the remote user
                 $this->linkAccount($providerUserId);
+                $currentUserLogin = Piwik::getCurrentUserLogin();
+                $this->assignPermissions($userOIDCPermissions, $currentUserLogin);
                 $this->redirectToIndex("UsersManager", "userSecurity");
             }
         } else {
@@ -275,11 +284,14 @@ class Controller extends \Piwik\Plugin\Controller
                 if ($settings->disableSuperuser->getValue() && $this->hasTheUserSuperUserAccess($user["login"])) {
                     throw new Exception(Piwik::translate("RebelOIDC_ExceptionSuperUserOauthDisabled"));
                 } else {
+
+                    $this->assignPermissions($userOIDCPermissions, $user['login']);
                     $this->signInAndRedirect($user, $settings);
                 }
             } else {
                 if (Piwik::getCurrentUserLogin() === $user["login"]) {
                     $this->passwordVerify->setPasswordVerifiedCorrectly();
+                    $this->assignPermissions($userOIDCPermissions, $user['login']);
                     return;
                 } else {
                     throw new Exception(Piwik::translate("RebelOIDC_ExceptionAlreadyLinkedToDifferentAccount"));
@@ -294,9 +306,10 @@ class Controller extends \Piwik\Plugin\Controller
      * @param  SystemSettings  $settings
      * @param  string          $providerUserId   Remote user id
      * @param  string          $providerEmail    Users email address
+     * @param  array           $permissions      Permissions for the user as array of tuples ['permission' => <permission>, 'siteID' => <siteID>]
      * @return void
      */
-    private function signupUser($settings, string $providerUserId, string $providerEmail = null, $result): void
+    private function signupUser($settings, string $providerUserId, string $providerEmail = null, $result, array $permissions = []): void
     {
         // only sign up user if setting is enabled
         if ($settings->allowSignup->getValue()) {
@@ -339,6 +352,7 @@ class Controller extends \Piwik\Plugin\Controller
             $userModel = new Model();
             $user = $userModel->getUser($userId);
             $this->linkAccount($providerUserId, $userId);
+            $this->assignPermissions($permissions, $user['login']);
             $this->signInAndRedirect($user, $settings);
         } else {
             throw new Exception(Piwik::translate("RebelOIDC_ExceptionUserNotFoundAndSignupDisabled"));
@@ -381,6 +395,36 @@ class Controller extends \Piwik\Plugin\Controller
                 "provider" => self::OIDC_PROVIDER
             );
             return Url::getCurrentUrlWithoutQueryString() . "?" . http_build_query($params);
+        }
+    }
+
+    /**
+     * @param array $permissions
+     * @param string $login
+     * @return void
+     *
+     * Receives a set of permissions as an array of tuples ['site' => <siteID>, 'access' => <permission>].
+     * Existing permissions of the given user that are not in this array are removed, missing permissions are added.
+     */
+    private function assignPermissions(array $permissions, string $login): void
+    {
+        $userModel = new Model();
+
+        // get the existing permissions for the user from the matomo_access table
+        $existingPermissions = $userModel->getSitesAccessFromUser($login);
+
+        // add permissions that are not yet in the matomo_access table for the user
+        foreach ($permissions as $permission) {
+            if(!in_array($permission, $existingPermissions)) {
+                $userModel->addUserAccess($login, $permission['access'], [$permission['site']]);
+            }
+        }
+
+        // remove permissions that are already matomo_access table for the user but not in the given set of permissions
+        foreach ($existingPermissions as $existingPermission) {
+            if(!in_array($existingPermission, $permissions)) {
+                $userModel->removeUserAccess($login, $existingPermission['access'], [$existingPermission['site']]);
+            }
         }
     }
 
@@ -447,6 +491,32 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         return $roles;
+    }
+
+    /**
+     * Extract Permissions from a decoded JWT token.
+     *
+     * Permissions are expected to be found in the claim "matomo-permission-path"
+     * in the format /matomo/<siteID>/<permission>).
+     * Available permissions are read, write and admin.
+     *
+     * @param array $decodedToken Decoded JWT payload.
+     * @return array permissions assigned to the user as array of tuples ['site' => <siteID>, 'access' => <permission>].
+     */
+    private function extractPermissions(array $decodedToken): array
+    {
+        $result = [];
+
+        if (isset($decodedToken['matomo-permission-path'])) {
+            foreach ($decodedToken['matomo-permission-path'] as $path) {
+                $groupPathParts = array_values(array_filter(explode('/', $path)));
+                if (count($groupPathParts) === 3 && $groupPathParts[0] === 'matomo' && in_array($groupPathParts[2], self::ALLOWED_PERMISSIONS)) {
+                    $result[] = ['site' => $groupPathParts[1], 'access' => $groupPathParts['2']];
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/Controller.php
+++ b/Controller.php
@@ -408,6 +408,13 @@ class Controller extends \Piwik\Plugin\Controller
      */
     private function assignPermissions(array $permissions, string $login): void
     {
+        // Check if fine-grained permissions are enabled in the settings
+        $settings = new SystemSettings();
+        // if it is disabled, return so that manually-managed permissions are not removed
+        if (!$settings->fineGrainedPermissions->getValue()) {
+            return;
+        }
+
         $userModel = new Model();
 
         // get the existing permissions for the user from the matomo_access table

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ You can set an initial site for all new users which logs in with OIDC for the fi
 
 If you have an organisation where not all in the organisations should have access, you can choose which role should have access to Matomo. The role needs to be part of the JWT token (default behavior in many OIDC providers, otherwise you need to configure it).
 
+## Fine-grained permissions
+
+You can set fine-grained permissions for users through adding a `matomo-permission-path` claim.
+In that claim, multiple permissions can be added as a path in the format `/matomo/<siteID>/<permission>`
+Available permissions are `admin`, `write` and `view` .
+If you are using Keycloak, this claim can be added to your token through creating a group/childgroup hierarchy and adding a custom group mapper for the matomo client.
+
 ## Sync users
 
 ### Keycloak

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ In that claim, multiple permissions can be added as a path in the format `/matom
 Available permissions are `admin`, `write` and `view` .
 If you are using Keycloak, this claim can be added to your token through creating a group/childgroup hierarchy and adding a custom group mapper for the matomo client.
 
+Fine-grained permissions can be enabled in the settings in Admin (cog wheel) -> System -> General settings -> Rebel OIDC.
+
 ## Sync users
 
 ### Keycloak

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -174,6 +174,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $allowedRole;
 
     /**
+     * Use fine-grained permissions from the "matomo-permission-path" claim of the token
+     *
+     * @var Setting
+     */
+    public $fineGrainedPermissions;
+
+    /**
      * Initialize the plugin settings.
      *
      * @var Setting
@@ -202,6 +209,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->allowedSignupDomains = $this->createAllowedSignupDomainsSetting();
         $this->initialIdSite = $this->createInitialIdSiteSetting();
         $this->allowedRole = $this->createAllowedRoleSetting();
+        $this->fineGrainedPermissions = $this->createFineGrainedPermissionsSetting();
     }
 
     /**
@@ -525,6 +533,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->title = Piwik::translate("RebelOIDC_SettingAllowedRole");
             $field->description = Piwik::translate("RebelOIDC_SettingAllowedRoleHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
+        });
+    }
+
+    /**
+     * Add fine grained permissions setting.
+     *
+     * @return SystemSetting
+     */
+    private function createFineGrainedPermissionsSetting(): SystemSetting
+    {
+        return $this->makeSetting("fineGrainedPermissions", $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+            $field->title = Piwik::translate("RebelOIDC_SettingFineGrainedPermissions");
+            $field->description = Piwik::translate("RebelOIDC_SettingFineGrainedPermissionsHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
         });
     }
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -34,6 +34,8 @@
     "SettingAllowedSignupDomainsHelp": "Wenn das Feld freigelassen wird, können sich Benutzer mit beliebiger E-Mail Adresse registrieren. Mehrere Domains können in separaten Zeilen angegeben werden.",
     "SettingAutoLinking": "Aktiviere Auto Linking",
     "SettingAutoLinkingHelp": "Aktiviert Auto Linking von Accounts, die die selbe User ID in Matomo und dem OpenID Connect Provider haben.",
+    "SettingFineGrainedPermissions": "Feingranulare Zugriffsrechte nutzen",
+    "SettingFineGrainedPermissionsHelp": "Wenn der Haken gesetzt ist, werden Zugriffsrechte anhand des \"matomo-permission-path\"-Claims aus dem Token gesetzt bzw. entfernt",
     "OpenIDConnect": "OpenID Connect",
     "OIDCIntro": "Dies erlaubt es Dir, Dich über einen externen Service bei Matomo einzuloggen.",
     "AccountLinked": "Dein Account ist zur Zeit verknüpft (Entfernte Benutzer-ID: %1$s).",

--- a/lang/en.json
+++ b/lang/en.json
@@ -36,6 +36,8 @@
     "SettingAllowedSignupDomainsHelp": "List of email domains which should be allowed to create new accounts. Multiple domains have to be separated by line breaks. When empty, any email domain will be accepted.",
     "SettingAutoLinking": "Enable auto linking",
     "SettingAutoLinkingHelp": "Enables auto linking of accounts which have the same user id in Matomo and the OIDC provider",
+    "SettingFineGrainedPermissions": "Use fine-grained permissions",
+    "SettingFineGrainedPermissionsHelp": "If this box is ticked, site access permissions are automatically added or removed based on the values in the \"matomo-permission-path\"-claim in the token.",
     "SettingsUsernameAttribute": "Username Attribute from OIDC claim",
     "SettingsUsernameAttributeHelp": "The OIDC claim to use as username (e.g., \"preferred_username\", \"email\", \"id\")",
     "SettingsFallbackToEmail": "Fallback to Email",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -32,6 +32,8 @@
     "SettingRedirectUriOverrideHelp": "Dans certains cas, il peut être pratique de redéfinir l'URI de redirection qui est transmise au fournisseur OpenID Connect. Si vous êtes n'êtes pas sûr, laissez ce champ vide.",
     "SettingAllowedSignupDomains": "Limiter la création d'utilisateurs aux domaines",
     "SettingAllowedSignupDomainsHelp": "",
+    "SettingFineGrainedPermissions": "Utiliser des permissions granulaires",
+    "SettingFineGrainedPermissionsHelp": "Si cette case est cochée, les autorisations d’accès au site sont automatiquement ajoutées ou supprimées en fonction des valeurs présentes dans la revendication \"matomo-permission-path\"-claim du jeton.",
     "OpenIDConnect": "OpenID Connect",
     "OIDCIntro": "Ceci vous permet de vous connecter à Matomo en utilisant un service d'authentification externe.",
     "AccountLinked": "Votre compte est actuellement lié (Identifiant du compte utilisateur distant : %1$s).",


### PR DESCRIPTION
Hello,
I have added the feature to set the matomo permissions for each site based on a Claim in the token. This claim can be added in Keycloak with a Group Mapper but it is not specific to Keycloak and can work with any IDP.

This addresses the Issues #25 and #31 .

I have made it configurable so that if it needs to be activated to take effect, so that it is not a breaking change.

The permissions can be mapped into a claim "matomo-permission-path" where they can be added like /matomo/<siteID>/<permission> with the permissions being view, write or admin.
Several permissions can be added for the user.

I have added a section in the README.

Please let me know if there are any changes or additional edits that I can make so that this feature is considered ready to merge.
Thanks!