### PR TITLE
Add email-based user lookup and improve OIDC autolinking in RebelOIDC plugin

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -256,8 +256,7 @@ class Controller extends \Piwik\Plugin\Controller
                 $matomoUser = $userModel->getUserByEmail($result->email);                                                          
             }  
             if (!empty($matomoUser)) {
-                
-                if (empty($user) && $userExists==false) {
+                if (empty($user)) {
                     $this->linkAccount($providerUserId, $matomoUser['login']);
                 }
                 $user = $this->getUserByRemoteId(self::OIDC_PROVIDER, $providerUserId);
@@ -291,7 +290,7 @@ class Controller extends \Piwik\Plugin\Controller
             }
         }
     }
-    
+
     /**
      * Sign up a new user and link him with a given remote user id.
      *

--- a/Controller.php
+++ b/Controller.php
@@ -252,9 +252,12 @@ class Controller extends \Piwik\Plugin\Controller
         if ($settings->autoLinking->getValue()) {
             $userModel = new Model();
             $matomoUser = $userModel->getUser($providerUserId);
+            if (empty($matomoUser)) {                                                                                      
+               $matomoUser = $this->getUserByEmail($result->email);                                                        
+            } 
             if (!empty($matomoUser)) {
                 if (empty($user)) {
-                    $this->linkAccount($providerUserId, $providerUserId);
+                    $this->linkAccount($providerUserId, $matomoUser['login']);
                 }
                 $user = $this->getUserByRemoteId(self::OIDC_PROVIDER, $providerUserId);
             }
@@ -288,6 +291,19 @@ class Controller extends \Piwik\Plugin\Controller
         }
     }
 
+    /**
+     * Look up a Matomo user by email address.
+     *
+     * @param  string  $email   The email address to search for.
+     * @return array|null       The Matomo user row if found, otherwise null.
+     */
+    private function getUserByEmail(string $email)                                                                             
+    {                                                                                                                          
+        $db = \Piwik\Db::get();                                                                                                
+        $sql = "SELECT * FROM " . $db->prefixTable('user') . " WHERE email = ?";                                               
+        return $db->fetchRow($sql, [$email]);                                                                                  
+    } 
+    
     /**
      * Sign up a new user and link him with a given remote user id.
      *

--- a/Controller.php
+++ b/Controller.php
@@ -252,11 +252,12 @@ class Controller extends \Piwik\Plugin\Controller
         if ($settings->autoLinking->getValue()) {
             $userModel = new Model();
             $matomoUser = $userModel->getUser($providerUserId);
-            if (empty($matomoUser)) {                                                                                      
-               $matomoUser = $this->getUserByEmail($result->email);                                                        
-            } 
+            if (empty($matomoUser) && !empty($result->email)) {                                                                    
+                $matomoUser = $userModel->getUserByEmail($result->email);                                                          
+            }  
             if (!empty($matomoUser)) {
-                if (empty($user)) {
+                
+                if (empty($user) && $userExists==false) {
                     $this->linkAccount($providerUserId, $matomoUser['login']);
                 }
                 $user = $this->getUserByRemoteId(self::OIDC_PROVIDER, $providerUserId);
@@ -290,19 +291,6 @@ class Controller extends \Piwik\Plugin\Controller
             }
         }
     }
-
-    /**
-     * Look up a Matomo user by email address.
-     *
-     * @param  string  $email   The email address to search for.
-     * @return array|null       The Matomo user row if found, otherwise null.
-     */
-    private function getUserByEmail(string $email)                                                                             
-    {                                                                                                                          
-        $db = \Piwik\Db::get();                                                                                                
-        $sql = "SELECT * FROM " . $db->prefixTable('user') . " WHERE email = ?";                                               
-        return $db->fetchRow($sql, [$email]);                                                                                  
-    } 
     
     /**
      * Sign up a new user and link him with a given remote user id.


### PR DESCRIPTION
## Summary

This MR improves the RebelOIDC plugin by adding email-based user lookup and enhancing the OIDC autolinking logic to better support Keycloak environments where email is the primary user identifier.

## What Changed

- Added a new helper method `getUserByEmail()` that retrieves a Matomo user by email.
- Updated `callback()` autolinking logic:
  - First attempts to match the provider user ID against Matomo `login`.
  - Falls back to email-based lookup when no login match is found.
  - Correctly uses the Matomo user’s `login` when calling `linkAccount()`.
- Ensures seamless linking when Keycloak uses email as the stable identifier (`userInfoId = email`).

## Why This Is Needed

Some Keycloak deployments use the email address as the canonical user identity.  
Matomo, however, resolves users by *login* only.  
This mismatch resulted in:

- failed autolinking,
- duplicate user creation attempts,
- signup failures when a Matomo user already existed with the same email.

This MR eliminates those issues by enabling reliable account matching via email.

## Impact

- Non-breaking change.
- Only affects OIDC login flow when `autoLinking` is enabled.
- Improves interoperability with Keycloak and reduces user account inconsistencies.

## Additional Notes

No changes to existing settings are required, but setting `userInfoId = email` is recommended if Keycloak is configured with email-based identities.
