### PR TITLE
FIX: Update permissions extraction from decoded token

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -248,7 +248,7 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         $user = $this->getUserByRemoteId(self::OIDC_PROVIDER, $providerUserId);
-        $userOIDCPermissions = $this->extractPermissions($decodedToken);
+        $userOIDCPermissions = $this->extractPermissions((array)$result);
 
 
         // auto linking


### PR DESCRIPTION
Error OKTA with 5.1.3

A fatal error occurred
Please contact the system administrator, or login to Matomo to learn more. If you are Super User, but cannot login because of this error, you can still troubleshoot further. Follow these steps: 1) open the config/config.ini.php file and look for the salt value under [General]. 2) edit this current URL you are viewing and add the following text (replacing salt_value_from_config by the salt value from the config file): index.php?i_am_super_user=salt_value_from_config&.
 
2026/02/02 14:17:58 [error] 622#622: *143 FastCGI sent in stderr: "PHP message: [XXX] Error in Matomo: Nous sommes désolés, mais l&#039;action que vous avez tenté d&#039;exécuter a échoué en raison d&#039;un contrôle de sécurité. Il s&#039;agit d&#039;une mesure habituelle visant à garantir la sûreté et la sécurité de votre compte. Veuillez réessayer, et si le problème persiste, veuillez contacter notre assistance technique pour obtenir une aide supplémentaire" while reading response header from upstream, client: XXX, server: , request: "POST /index.php?module=RebelOIDC&action=signIn&period=day&date=yesterday&activated= HTTP/1.1", upstream: "fastcgi://unix:/var/run/php-fpm/php-fpm.sock:"