### PR TITLE
Add accessToken variable

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -211,6 +211,7 @@ class Controller extends \Piwik\Plugin\Controller
         $response = curl_exec($curl);
         curl_close($curl);
         $result = json_decode($response);
+        $accessToken = $result->access_token;
         // If id_token exists, merge its decoded content with access token's decoded content
         if (property_exists($result, 'id_token')) {
             $idToken = $result->id_token;


### PR DESCRIPTION
I somehow managed to forget to add the `$accessToken` variable in the latest PR.
This will fix the problem.

Sorry about that.