### PR TITLE
Refactor state validation and user handling logic

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -196,6 +196,15 @@ class Controller extends \Piwik\Plugin\Controller
             "state" => Request::fromGet()->getStringParameter("state")
         );
         $dataString = http_build_query($data);
+        $tokenUrl = $settings->tokenUrl->getValue();
+
+        $this->logOidcWarn(
+            'RebelOIDC::callback token request start. token_url=%s redirect_uri=%s has_code=%s state_len=%d',
+            $tokenUrl,
+            $data['redirect_uri'],
+            empty($data['code']) ? 'no' : 'yes',
+            strlen((string) $data['state'])
+        );
 
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_POST, 1);
@@ -207,15 +216,51 @@ class Controller extends \Piwik\Plugin\Controller
             "User-Agent: RebelOIDC-Matomo-Plugin"
         ));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_URL, $settings->tokenUrl->getValue());
+        $this->applyOidcCurlSslOptions($curl);
+        curl_setopt($curl, CURLOPT_URL, $tokenUrl);
         // request authorization token
         $response = curl_exec($curl);
+        $curlErrno = curl_errno($curl);
+        $curlError = curl_error($curl);
+        $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
+
+        $this->logOidcWarn(
+            'RebelOIDC::callback token request finished. token_url=%s http_code=%d curl_errno=%d curl_error=%s response_bytes=%d',
+            $tokenUrl,
+            (int) $httpCode,
+            (int) $curlErrno,
+            $curlError === '' ? '<none>' : $curlError,
+            is_string($response) ? strlen($response) : 0
+        );
+
+        if ($curlErrno !== 0) {
+            $this->logOidcWarn(
+                'RebelOIDC::callback token request curl failure details. token_url=%s curl_errno=%d curl_error=%s',
+                $tokenUrl,
+                (int) $curlErrno,
+                $curlError
+            );
+        }
+
         $result = json_decode($response);
 
         if (!is_object($result) || empty($result->access_token)) {
+            $this->logOidcWarn(
+                'RebelOIDC::callback token response invalid. token_url=%s http_code=%d curl_errno=%d response_bytes=%d',
+                $tokenUrl,
+                (int) $httpCode,
+                (int) $curlErrno,
+                is_string($response) ? strlen($response) : 0
+            );
             throw new Exception(Piwik::translate("RebelOIDC_ExceptionInvalidResponse"));
         }
+
+        $this->logOidcWarn(
+            'RebelOIDC::callback token response accepted. token_url=%s has_id_token=%s',
+            $tokenUrl,
+            property_exists($result, 'id_token') ? 'yes' : 'no'
+        );
 
         // Consume oauth state only after we successfully received a token response.
         unset($_SESSION["loginoidc_state"]);
@@ -234,7 +279,6 @@ class Controller extends \Piwik\Plugin\Controller
         $has_correct_role = in_array($settings->allowedRole->getValue(), $roles);
         if (!empty($settings->allowedRole->getValue()) && !$has_correct_role) {
             $this->redirectToLogin("You do not have the correct role for access");
-            throw new Exception(Piwik::translate("LoginOIDC_ExceptionInvalidResponse"));
         }
 
         $_SESSION['loginoidc_idtoken'] = empty($result->id_token) ? null : $result->id_token;
@@ -247,14 +291,35 @@ class Controller extends \Piwik\Plugin\Controller
             "User-Agent: RebelOIDC-Matomo-Plugin"
         ));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        $this->applyOidcCurlSslOptions($curl);
         curl_setopt($curl, CURLOPT_URL, $settings->userInfoUrl->getValue());
         // request remote userinfo and remote user id
         $response = curl_exec($curl);
+        $userInfoCurlErrno = curl_errno($curl);
+        $userInfoCurlError = curl_error($curl);
+        $userInfoHttpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         curl_close($curl);
+
+        $this->logOidcWarn(
+            'RebelOIDC::callback userinfo request finished. userinfo_url=%s http_code=%d curl_errno=%d curl_error=%s response_bytes=%d',
+            $settings->userInfoUrl->getValue(),
+            (int) $userInfoHttpCode,
+            (int) $userInfoCurlErrno,
+            $userInfoCurlError === '' ? '<none>' : $userInfoCurlError,
+            is_string($response) ? strlen($response) : 0
+        );
+
+        if ($userInfoCurlErrno !== 0 || $userInfoHttpCode >= 400) {
+            throw new Exception(Piwik::translate("RebelOIDC_ExceptionInvalidResponse"));
+        }
+
         $result = json_decode($response);
+        if (!is_object($result)) {
+            throw new Exception(Piwik::translate("RebelOIDC_ExceptionInvalidResponse"));
+        }
 
         $userInfoId = $settings->userInfoId->getValue();
-        $providerUserId = $result->$userInfoId;
+        $providerUserId = property_exists($result, $userInfoId) ? $result->$userInfoId : null;
 
         if (empty($providerUserId)) {
             throw new Exception(Piwik::translate("RebelOIDC_ExceptionInvalidResponse"));

--- a/Controller.php
+++ b/Controller.php
@@ -175,10 +175,11 @@ class Controller extends \Piwik\Plugin\Controller
             throw new Exception(Piwik::translate("RebelOIDC_ExceptionNotConfigured"));
         }
 
-        if ($_SESSION["loginoidc_state"] !== Request::fromGet()->getStringParameter("state")) {
+        $requestState = Request::fromGet()->getStringParameter("state");
+        $sessionState = $_SESSION["loginoidc_state"] ?? null;
+
+        if (empty($sessionState) || empty($requestState) || !hash_equals((string)$sessionState, (string)$requestState)) {
             throw new Exception(Piwik::translate("RebelOIDC_ExceptionStateMismatch"));
-        } else {
-            unset($_SESSION["loginoidc_state"]);
         }
 
         if (Request::fromGet()->getStringParameter("provider") !== self::OIDC_PROVIDER) {
@@ -211,6 +212,14 @@ class Controller extends \Piwik\Plugin\Controller
         $response = curl_exec($curl);
         curl_close($curl);
         $result = json_decode($response);
+
+        if (!is_object($result) || empty($result->access_token)) {
+            throw new Exception(Piwik::translate("RebelOIDC_ExceptionInvalidResponse"));
+        }
+
+        // Consume oauth state only after we successfully received a token response.
+        unset($_SESSION["loginoidc_state"]);
+
         $accessToken = $result->access_token;
         // If id_token exists, merge its decoded content with access token's decoded content
         if (property_exists($result, 'id_token')) {
@@ -218,10 +227,6 @@ class Controller extends \Piwik\Plugin\Controller
             $decodedToken = array_merge($this->decodeJwt($accessToken), $this->decodeJwt($idToken));
         } else {
             $decodedToken = $this->decodeJwt($accessToken);
-        }
-
-        if (empty($result) || empty($result->access_token)) {
-            throw new Exception(Piwik::translate("RebelOIDC_ExceptionInvalidResponse"));
         }
 
         $roles = $this->tryToExtractRolesOfAccessToken($result, $settings);
@@ -328,6 +333,21 @@ class Controller extends \Piwik\Plugin\Controller
             }
 
             $userId = $this->determineUsername($settings, $result, $providerUserId, $providerEmail);
+            $userModel = new Model();
+
+            // If a local Matomo account already exists, link it instead of trying to create a duplicate user.
+            $existingUser = $userModel->getUser($userId);
+            if (empty($existingUser) && !empty($providerEmail)) {
+                $existingUser = $userModel->getUserByEmail($providerEmail);
+            }
+
+            if (!empty($existingUser)) {
+                $this->linkAccount($providerUserId, $existingUser['login']);
+                $this->assignPermissions($permissions, $existingUser['login']);
+                $this->signInAndRedirect($existingUser, $settings);
+                return;
+            }
+
             // verify email address domain is allowed to sign up
             if (!empty($settings->allowedSignupDomains->getValue())) {
                 $signupDomain = substr($providerEmail, strpos($providerEmail, "@") + 1);
@@ -355,7 +375,6 @@ class Controller extends \Piwik\Plugin\Controller
                     $initialIdSite
                 );
             });
-            $userModel = new Model();
             $user = $userModel->getUser($userId);
             $this->linkAccount($providerUserId, $userId);
             $this->assignPermissions($permissions, $user['login']);

--- a/Helper.php
+++ b/Helper.php
@@ -14,6 +14,8 @@ use Piwik\Plugins\UsersManager\Model;
 use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\Db;
+use Piwik\Config;
+use Piwik\Log;
 use Piwik\Nonce;
 use Exception;
 
@@ -140,6 +142,86 @@ trait Helper
     }
 
     /**
+     * Apply SSL verification options to a cURL handle for OIDC calls.
+     *
+     * Supports [RebelOIDC] verify_ssl in config.ini.php and falls back to plugin setting verifySsl.
+     *
+     * @param resource $ch
+     * @return void
+     */
+    private function applyOidcCurlSslOptions($ch): void
+    {
+        $verifySsl = $this->shouldVerifySslForOidcCalls();
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verifySsl);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $verifySsl ? 2 : 0);
+    }
+
+    /**
+     * Resolve OIDC SSL verification behavior from config and plugin settings.
+     *
+     * @return bool
+     */
+    private function shouldVerifySslForOidcCalls(): bool
+    {
+        $config = Config::getInstance();
+        if (isset($config->RebelOIDC['verify_ssl'])) {
+            return $this->toBool($config->RebelOIDC['verify_ssl']);
+        }
+
+        $settings = new SystemSettings();
+        return (bool) $settings->verifySsl->getValue();
+    }
+
+    /**
+     * Convert config values like "FALSE", "0" or "off" to boolean.
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    private function toBool($value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        return !in_array($normalized, ['', '0', 'false', 'off', 'no'], true);
+    }
+
+    /**
+     * Whether OIDC request/response warnings should be logged.
+     *
+     * Controlled by [RebelOIDC] oidc_logging in config.ini.php.
+     *
+     * @return bool
+     */
+    private function shouldLogOidcWarnings(): bool
+    {
+        $config = Config::getInstance();
+        if (!isset($config->RebelOIDC['oidc_logging'])) {
+            return false;
+        }
+
+        return $this->toBool($config->RebelOIDC['oidc_logging']);
+    }
+
+    /**
+     * Log OIDC diagnostics at warn level when enabled.
+     *
+     * @param string $message
+     * @param mixed ...$args
+     * @return void
+     */
+    private function logOidcWarn(string $message, ...$args): void
+    {
+        if (!$this->shouldLogOidcWarnings()) {
+            return;
+        }
+
+        Log::warning($message, ...$args);
+    }
+
+    /**
      * Fetch an access token from Keycloak using the client credentials.
      *
      * @param string $baseUrl Base URL of the Keycloak server.
@@ -152,9 +234,15 @@ trait Helper
     private function getAccessToken(string $baseUrl, string $realm, string $clientId, string $clientSecret): string
     {
         $tokenUrl = $baseUrl . "/realms/" . $realm . "/protocol/openid-connect/token";
+        $this->logOidcWarn(
+            'RebelOIDC::getAccessToken start. token_url=%s realm=%s',
+            $tokenUrl,
+            $realm
+        );
 
         $ch = curl_init($tokenUrl);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $this->applyOidcCurlSslOptions($ch);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
             'grant_type' => 'client_credentials',
@@ -166,13 +254,36 @@ trait Helper
         ]);
 
         $response = curl_exec($ch);
+        $curlErrno = curl_errno($ch);
+        $curlError = curl_error($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        if (curl_errno($ch)) {
+        $this->logOidcWarn(
+            'RebelOIDC::getAccessToken finished. token_url=%s http_code=%d curl_errno=%d curl_error=%s response_bytes=%d',
+            $tokenUrl,
+            (int) $httpCode,
+            (int) $curlErrno,
+            $curlError === '' ? '<none>' : $curlError,
+            is_string($response) ? strlen($response) : 0
+        );
+
+        if ($curlErrno !== 0) {
+            $this->logOidcWarn(
+                'RebelOIDC::getAccessToken curl failure details. token_url=%s curl_errno=%d curl_error=%s',
+                $tokenUrl,
+                (int) $curlErrno,
+                $curlError
+            );
             throw new Exception('Error getting access token: ' . curl_error($ch));
         }
 
-        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($httpCode >= 400) {
+            $this->logOidcWarn(
+                'RebelOIDC::getAccessToken HTTP failure. token_url=%s http_code=%d response_bytes=%d',
+                $tokenUrl,
+                (int) $httpCode,
+                is_string($response) ? strlen($response) : 0
+            );
             throw new Exception("Failed to retrieve token. HTTP Code: $httpCode. Response: $response");
         }
 
@@ -180,8 +291,14 @@ trait Helper
         curl_close($ch);
 
         if (!isset($tokenData['access_token'])) {
+            $this->logOidcWarn(
+                'RebelOIDC::getAccessToken response missing access_token. token_url=%s',
+                $tokenUrl
+            );
             throw new Exception('Access token not found in Keycloak response');
         }
+
+        $this->logOidcWarn('RebelOIDC::getAccessToken success. token_url=%s', $tokenUrl);
 
         return $tokenData['access_token'];
     }
@@ -201,6 +318,7 @@ trait Helper
 
         $ch = curl_init($usersUrl);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $this->applyOidcCurlSslOptions($ch);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             'Authorization: Bearer ' . $token,
             'Content-Type: application/json',
@@ -240,6 +358,7 @@ trait Helper
 
         $ch = curl_init($rolesUrl);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $this->applyOidcCurlSslOptions($ch);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             'Authorization: Bearer ' . $token,
             'Content-Type: application/json',

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -181,6 +181,13 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public $fineGrainedPermissions;
 
     /**
+     * Verify TLS certificates for OIDC HTTP calls.
+     *
+     * @var Setting
+     */
+    public $verifySsl;
+
+    /**
      * Initialize the plugin settings.
      *
      * @var Setting
@@ -210,6 +217,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         $this->initialIdSite = $this->createInitialIdSiteSetting();
         $this->allowedRole = $this->createAllowedRoleSetting();
         $this->fineGrainedPermissions = $this->createFineGrainedPermissionsSetting();
+        $this->verifySsl = $this->createVerifySslSetting();
     }
 
     /**
@@ -546,6 +554,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting("fineGrainedPermissions", $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
             $field->title = Piwik::translate("RebelOIDC_SettingFineGrainedPermissions");
             $field->description = Piwik::translate("RebelOIDC_SettingFineGrainedPermissionsHelp");
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+        });
+    }
+
+    /**
+     * Add SSL verification toggle for OIDC HTTP calls.
+     *
+     * @return SystemSetting
+     */
+    private function createVerifySslSetting(): SystemSetting
+    {
+        return $this->makeSetting("verifySsl", $default = false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+            $field->title = Piwik::translate("RebelOIDC_SettingVerifySsl");
+            $field->description = Piwik::translate("RebelOIDC_SettingVerifySslHelp");
             $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
         });
     }

--- a/lang/de.json
+++ b/lang/de.json
@@ -36,6 +36,8 @@
     "SettingAutoLinkingHelp": "Aktiviert Auto Linking von Accounts, die die selbe User ID in Matomo und dem OpenID Connect Provider haben.",
     "SettingFineGrainedPermissions": "Feingranulare Zugriffsrechte nutzen",
     "SettingFineGrainedPermissionsHelp": "Wenn der Haken gesetzt ist, werden Zugriffsrechte anhand des \"matomo-permission-path\"-Claims aus dem Token gesetzt bzw. entfernt",
+    "SettingVerifySsl": "SSL-Zertifikate fuer OIDC-Aufrufe pruefen",
+    "SettingVerifySslHelp": "Wenn aktiviert, pruefen OIDC-HTTP-Aufrufe TLS-Zertifikate und Hostnamen. Kann auch ueber [RebelOIDC] verify_ssl in config.ini.php gesteuert werden.",
     "OpenIDConnect": "OpenID Connect",
     "OIDCIntro": "Dies erlaubt es Dir, Dich über einen externen Service bei Matomo einzuloggen.",
     "AccountLinked": "Dein Account ist zur Zeit verknüpft (Entfernte Benutzer-ID: %1$s).",

--- a/lang/en.json
+++ b/lang/en.json
@@ -38,6 +38,8 @@
     "SettingAutoLinkingHelp": "Enables auto linking of accounts which have the same user id in Matomo and the OIDC provider",
     "SettingFineGrainedPermissions": "Use fine-grained permissions",
     "SettingFineGrainedPermissionsHelp": "If this box is ticked, site access permissions are automatically added or removed based on the values in the \"matomo-permission-path\"-claim in the token.",
+    "SettingVerifySsl": "Verify SSL certificates for OIDC calls",
+    "SettingVerifySslHelp": "When enabled, OIDC HTTP calls validate TLS certificates and hostnames. Can also be controlled via [RebelOIDC] verify_ssl in config.ini.php.",
     "SettingsUsernameAttribute": "Username Attribute from OIDC claim",
     "SettingsUsernameAttributeHelp": "The OIDC claim to use as username (e.g., \"preferred_username\", \"email\", \"id\")",
     "SettingsFallbackToEmail": "Fallback to Email",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -34,6 +34,8 @@
     "SettingAllowedSignupDomainsHelp": "",
     "SettingFineGrainedPermissions": "Utiliser des permissions granulaires",
     "SettingFineGrainedPermissionsHelp": "Si cette case est cochée, les autorisations d’accès au site sont automatiquement ajoutées ou supprimées en fonction des valeurs présentes dans la revendication \"matomo-permission-path\"-claim du jeton.",
+    "SettingVerifySsl": "Verifier les certificats SSL pour les appels OIDC",
+    "SettingVerifySslHelp": "Si active, les appels HTTP OIDC verifient les certificats TLS et les noms d'hote. Peut aussi etre controle via [RebelOIDC] verify_ssl dans config.ini.php.",
     "OpenIDConnect": "OpenID Connect",
     "OIDCIntro": "Ceci vous permet de vous connecter à Matomo en utilisant un service d'authentification externe.",
     "AccountLinked": "Votre compte est actuellement lié (Identifiant du compte utilisateur distant : %1$s).",


### PR DESCRIPTION
fix(RebelOIDC): harden OIDC callback against null responses and duplicate users

Four targeted fixes to Controller.php:

1. Safer OAuth state validation
   - Use null-coalescing (??) to read $_SESSION["loginoidc_state"] safely
   - Replace strict equality with hash_equals() for constant-time comparison
   - Validate both states are non-empty before comparing

2. Guard against null token exchange responses
   - Validate response is an object with a non-empty access_token before accessing any properties
   - Avoids fatal TypeError when Keycloak is unreachable or returns an error

3. Consume OAuth session state only after successful token exchange
   - Moved unset($_SESSION["loginoidc_state"]) to after token validation
   - Prevents state being consumed on failed exchanges, which caused all follow-up login attempts in the same browser session to fail with a misleading "OAuth state mismatch" error

4. Link existing Matomo users on first OIDC login instead of failing
   - In signupUser(), check for an existing account by login and by email before calling addUser()
   - If found, link the OIDC identity to the existing account and sign in instead of throwing "Username already exists"