### PR TITLE
Fix/jwt with non-latin symbols

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -205,6 +205,8 @@ class Controller extends \Piwik\Plugin\Controller
             "Accept: application/json",
             "User-Agent: RebelOIDC-Matomo-Plugin"
         ));
+        // curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);  // in case you want to ignore SSL
+        // curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);  // in case you want to ignore SSL
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_URL, $settings->tokenUrl->getValue());
         // request authorization token
@@ -241,6 +243,8 @@ class Controller extends \Piwik\Plugin\Controller
             "Accept: application/json",
             "User-Agent: RebelOIDC-Matomo-Plugin"
         ));
+        // curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);  // in case you want to ignore SSL
+        // curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);  // in case you want to ignore SSL
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_URL, $settings->userInfoUrl->getValue());
         // request remote userinfo and remote user id

--- a/Controller.php
+++ b/Controller.php
@@ -471,10 +471,19 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         // Base64-decode the payload (second part of the JWT)
-        $payload = base64_decode($parts[1]);
+        $base64 = strtr($parts[1], '-_', '+/');
+        $padded = str_pad(
+            $base64,
+            strlen($base64) + (4 - strlen($base64) % 4) % 4,
+            '='
+        );
+        $payload = base64_decode($padded, true);
+        if ($payload === false) {
+            throw new Exception('Failed to base64-decode JWT payload.')
+        }
 
         // Convert JSON payload to a PHP array
-        $decoded = json_decode($payload, true);
+        $decoded = json_decode($payload, true, 512, JSON_INVALID_UTF8_IGNORE);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new Exception('Failed to decode JWT payload: ' . json_last_error_msg());
         }


### PR DESCRIPTION
# summary
Updating function `decodeJwt` in file `Controller.php`.
This PR improves RebelOIDC so the JWT provided by SSO provider (Keycloak in our case) is parsed correctly even it contains non-latin symbols in it. 

Additionally ignorance of ssl certificate errors is added (commented).

# description
After some researches we found out that the JWT was parsed incorrectly so we made local fixes to the downloaded plugin files. As we found we are not unique with this so I'm kindly sharing our working solution and I hope it might be helpful for others.

What counts to ssl certificates – we use dynamic self-signed certificates for SSO provider so we added some lines to the code to ignore untrusted certs as the responses/logs for this issue were completely unclear.
The hack is commented out so the certificates are not ignored unless it's explicitly set. Hope this might also save some time for everyone facing the similar issue. 

# notes 
we are not much into PHP code so we hope the solution is at least acceptable 😄